### PR TITLE
A new method to fetch AESO data for all years

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,7 @@
 import sys
+
+import pandas as pd
+
 from utils.constants import AESO_API_KEY, BASE_URL, CURRENT_SUPPLY_DEMAND_URL, INTERNAL_LOAD_URL, POOL_PRICE_REPORT
 from scrape.aeso_scraper import AESOfetcher
 from scrape.weather_canada import DownloadWeatherData
@@ -32,10 +35,22 @@ def main() -> int:
 
 
 	# Fetch Alberta Internal Load data for all years
-	internal_load_data = fetcher.fetch_data_all_years(INTERNAL_LOAD_URL, 2003, 2023)
+	internal_load_data = fetcher.fetch_data_all_years(INTERNAL_LOAD_URL, 2003, 2023, ["alberta_internal_load"])
 
 	# Fetch Pool Price data for all years
-	pool_price_data = fetcher.fetch_data_all_years(POOL_PRICE_REPORT, 2003, 2023)
+	pool_price_data = fetcher.fetch_data_all_years(POOL_PRICE_REPORT, 2003, 2023, ["pool_price", "rolling_30day_avg"])
+
+	# create a dataframe and lineup the 3 separate headers that you have above with the correct date
+	feature_list = pd.DataFrame()
+
+	# your feature list will look something like the chart below...
+	# Date || alberta_internal_load || pool_price || rolling_30day_avg -> for the headers
+	# 2003-01-01 || 98375 || 23.43 || 65.3 --> this will be one row entry
+	# ... repeat that for the remaining 20 years
+
+	# check if the dataframe contains nan values
+	# check if all of the dates are present
+	# check for data that is out of range, if you pull down a temperature was +500*C
 
 	# Testing: Print first 5 entries of the Alberta Internal Load data
 	print("First 5 entries of Alberta Internal Load data:")

--- a/main.py
+++ b/main.py
@@ -30,6 +30,22 @@ def main() -> int:
 
 	print(f"Total Load for 2015: {load_sum}")
 
+
+	# Fetch Alberta Internal Load data for all years
+	internal_load_data = fetcher.fetch_data_all_years(INTERNAL_LOAD_URL, 2003, 2023)
+
+	# Fetch Pool Price data for all years
+	pool_price_data = fetcher.fetch_data_all_years(POOL_PRICE_REPORT, 2003, 2023)
+
+	# Testing: Print first 5 entries of the Alberta Internal Load data
+	print("First 5 entries of Alberta Internal Load data:")
+	print(internal_load_data[:5])
+
+	# Testing: Print first 5 entries of the Pool Price data
+	print("\nFirst 5 entries of Pool Price data:")
+	print(pool_price_data[:5])
+
+
 	# Try fetching Current Supply Demand
 	# current_supply_demand, status_code = fetcher.fetch_data(CURRENT_SUPPLY_DEMAND_URL)
 	# if status_code == -1:

--- a/scrape/aeso_scraper.py
+++ b/scrape/aeso_scraper.py
@@ -28,4 +28,39 @@ class AESOfetcher:
             print(f"Error fetching  data: {e}")
             return None, getattr(e.response, 'status_code', -1)
 
+    def fetch_data_all_years(self, dataset, start_year, end_year):
+        """A method to fetch data all years in the specified range and store it in memory. 
+        This will return a list of dictionaries.
+        
+        dataset: The dataset name to be appended to the base URL mentioned above.
+        start_year: The starting year of the range.
+        end_year: The ending year of the range.
+        """
 
+        # Create an empty list for fetched data
+        combined_data = []
+
+        # Iterate over each year in the range
+        for year in range(start_year, end_year+1):
+            startDate = f"{year}-01-01"
+            endDate = f"{year}-12-31"
+            params = {'startDate': startDate, 'endDate': endDate}
+            response_data, status_code = self.fetch_data(dataset, params)
+
+            # Check if API call was successful
+            if status_code == -1:
+                print(f"The API failed to fetch the data from the request, please look at the API key and the base url being made in the request")
+                return status_code
+            else:
+                print(f"Status Code: {status_code} for year {year}")
+
+            # API calls depending on the URL of datasets
+            if dataset.endswith('albertaInternalLoad'):
+                yearly_data = response_data.get('return',{}).get('Actual Forecast Report',[])
+            elif dataset.endswith('poolPrice'):
+                yearly_data = response_data.get('return',{}).get('Pool Price Report',[])
+            
+            # Append the yearly data to the list
+            combined_data.extend(yearly_data)
+
+        return combined_data


### PR DESCRIPTION
As per Chris' advice, I've made some changes to 2 files: aeso_scraper.py and main.py as follows:

- Created a new method called `fetch_data_all_years` using a For loop to iterate over the range of years (e.g. 2003 to 2023) and store them in memory (instead of writing them to disk as CSV files).
- Called this new method in `main.py`. 
- Tested to see if the results returned properly by printing the first 5 entries in each list. It worked when I tried it.